### PR TITLE
Redis 始终 提示 ERROR

### DIFF
--- a/lib/status-page/services/redis.rb
+++ b/lib/status-page/services/redis.rb
@@ -1,5 +1,3 @@
-require 'redis/namespace'
-
 module StatusPage
   module Services
     class RedisException < StandardError; end
@@ -9,7 +7,7 @@ module StatusPage
         attr_accessor :url
 
         def initialize
-          @url = "redis://127.0.0.1:3306/1"
+          @url = "redis://127.0.0.1:6379/1"
         end
       end
 
@@ -30,7 +28,7 @@ module StatusPage
       rescue Exception => e
         raise RedisException.new(e.message)
       ensure
-        redis.disconnect
+        redis.close
       end
 
       private


### PR DESCRIPTION
1. 去掉了 `require 'redis/namespace'`
2. 将默认端口由MySQL `3306` 改为 Redis默认端口 `6379`
3. 现在已经没有 `disconnect` 方法了，改为 `close`

以上，现在可以正常显示 `OK` 了

![image](https://user-images.githubusercontent.com/57120683/73959813-de09a800-4944-11ea-850e-8f07faadaa25.png)

![image](https://user-images.githubusercontent.com/57120683/73959871-f37ed200-4944-11ea-9687-87f2f4db72a9.png)

![image](https://user-images.githubusercontent.com/57120683/73959920-042f4800-4945-11ea-88bc-56f08db4c648.png)

烦请通过，并更新到 Gem