### PR TITLE
Update redis.rb

### DIFF
--- a/lib/status-page/services/redis.rb
+++ b/lib/status-page/services/redis.rb
@@ -18,7 +18,7 @@ module StatusPage
       end
 
       def check!
-        time = Time.now.to_s(:db)
+        time = Time.now.to_fs(:db)
 
         redis = ::Redis.new(url: config.url)
         redis.set(key, time)


### PR DESCRIPTION
Rails 7 中，`Time.now.to_s`不支持任何参数，需要使用`to_fs`或`to_formatted_s`代替。

<img width="761" alt="image" src="https://user-images.githubusercontent.com/57120683/155830971-b7abc24a-850f-43c9-9826-edc9618c85b3.png">

通过后，麻烦提交到 https://rubygems.org 哦